### PR TITLE
Add summary.md to support gitbook

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,17 @@
+# Summary
+
+* [标准命令详解](0.0.md)
+   * [go build](0.1.md)
+   * [go install](0.2.md)
+   * [go get](0.3.md)
+   * [go clean](0.4.md)
+   * [godoc](0.5.md)
+   * [go run](0.6.md)
+   * [go test](0.7.md)
+   * [go list](0.8.md)
+   * [go fmt与go tool fix](0.10.md)
+   * [go vet与go tool vet](0.11.md)
+   * [go tool pprof](0.12.md)
+   * [go tool cgo](0.13.md)
+   * [go env](0.14.md)
+


### PR DESCRIPTION
It looks really great and I just add `SUMMARY.md`. We can publish on gitbook.com or read it locally.

Usage: `gitbook serve .` then go to `http://127.0.0.1:4000`.

![go_command_tutorial_gitbook](https://cloud.githubusercontent.com/assets/2715000/6525804/262adabc-c445-11e4-9280-5ccbff521499.png)
